### PR TITLE
Allow modification of the Contact: hostname

### DIFF
--- a/lib/endpoint.rb
+++ b/lib/endpoint.rb
@@ -11,7 +11,7 @@ require 'digest/md5'
 
 module Quaff
   class BaseEndpoint
-    attr_accessor :msg_trace, :uri, :sdp_port, :sdp_socket
+    attr_accessor :msg_trace, :uri, :sdp_port, :sdp_socket, :local_hostname
     attr_reader :msg_log, :local_port, :instance_id
 
     # Creates an SDP socket bound to an ephemeral port
@@ -114,6 +114,7 @@ module Quaff
       @contact_params = {}
       @contact_uri_params = {"transport" => transport, "ob" => true}
       @terminated = false
+      @local_hostname = Utils::local_ip
       initialize_queues
       start
     end
@@ -121,7 +122,7 @@ module Quaff
     def contact_header
       param_str = Utils.paramhash_to_str(@contact_params)
       uri_param_str = Utils.paramhash_to_str(@contact_uri_params)
-      "<sip:quaff@#{Utils::local_ip}:#{@local_port}#{uri_param_str}>#{param_str}"
+      "<sip:quaff@#{@local_hostname}:#{@local_port}#{uri_param_str}>#{param_str}"
     end
 
     def send_msg(data, source) # :nodoc:


### PR DESCRIPTION
Allows Quaff to be used behind a static NAT without relying on `outbound` support from the SIP deployment.  Simply set the `local_hostname` on the endpoint and the `Contact:` header will be filled in with that hostname.
